### PR TITLE
Expose TokenResponse, Refresh and Get Token in a HttpClient Factory

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit.Console" version="3.5.0" />
+  <package id="NUnit.ConsoleRunner" version="3.5.0" />
+  <package id="NUnit.Extension.NUnitProjectLoader" version="3.5.0" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.5.0" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" />
+  <package id="NUnit.Extension.VSProjectLoader" version="3.5.0" />
+  <package id="NUnit.Runners" version="3.5.0" />
+</packages>

--- a/src/OAuth2ClientHandler/Authorizer/Authorizer.cs
+++ b/src/OAuth2ClientHandler/Authorizer/Authorizer.cs
@@ -87,7 +87,7 @@ namespace OAuth2ClientHandler.Authorizer
         private async Task<TokenResponse> RefreshTokenWithClientCredentials(TokenResponse tokenResponse, CancellationToken cancellationToken)
         {
             if (options.TokenEndpointUrl == null) throw new ArgumentNullException("TokenEndpointUrl");
-            if (tokenResponse == null || tokenResponse.RefreshToken == null) throw new ArgumentNullException("TokenResponse");
+            if (tokenResponse == null || tokenResponse.RefreshToken == null) return null;
             if (!options.TokenEndpointUrl.IsAbsoluteUri) throw new ArgumentException("TokenEndpointUrl must be absolute");
             using (var client = this.createHttpClient())
             {

--- a/src/OAuth2ClientHandler/Authorizer/IAuthorizer.cs
+++ b/src/OAuth2ClientHandler/Authorizer/IAuthorizer.cs
@@ -6,5 +6,7 @@ namespace OAuth2ClientHandler.Authorizer
     internal interface IAuthorizer
     {
         Task<TokenResponse> GetToken(CancellationToken? cancellationToken = null);
+
+        Task<TokenResponse> RefreshToken(TokenResponse tokenResponse, CancellationToken? cancellationToken = null);
     }
 }

--- a/src/OAuth2ClientHandler/Authorizer/TokenResponse.cs
+++ b/src/OAuth2ClientHandler/Authorizer/TokenResponse.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization;
 namespace OAuth2ClientHandler.Authorizer
 {
     [DataContract]
-    internal class TokenResponse
+    public class TokenResponse
     {
         [DataMember(Name = "access_token")]
         public string AccessToken { get; set; }

--- a/src/OAuth2ClientHandler/OAuth2ClientHandler.csproj
+++ b/src/OAuth2ClientHandler/OAuth2ClientHandler.csproj
@@ -36,6 +36,10 @@
       <HintPath>..\..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
       <Private>True</Private>
@@ -55,6 +59,7 @@
     <Compile Include="Authorizer\Authorizer.cs" />
     <Compile Include="Authorizer\AuthorizerOptions.cs" />
     <Compile Include="GrantType.cs" />
+    <Compile Include="OAuthHttpClient.cs" />
     <Compile Include="OAuthHttpHandler.cs" />
     <Compile Include="OAuthHttpHandlerOptions.cs" />
     <Compile Include="ProtocolException.cs" />

--- a/src/OAuth2ClientHandler/OAuthHttpClient.cs
+++ b/src/OAuth2ClientHandler/OAuthHttpClient.cs
@@ -1,0 +1,58 @@
+﻿using OAuth2ClientHandler.Authorizer;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OAuth2ClientHandler
+{
+    public class OAuthHttpClient : HttpClient
+    {
+        public OAuthHttpHandler oAuthHttpHandler { get; set; }
+        public TokenResponse tokenResponse { 
+            get {
+                return oAuthHttpHandler.tokenResponse;
+            } 
+        }
+
+        private OAuthHttpClient(HttpMessageHandler handler, bool disposeHandler)
+            : base(handler, disposeHandler)
+        {
+
+        }
+        private OAuthHttpClient(HttpMessageHandler handler)
+            : base(handler)
+        {
+
+        }
+
+        private OAuthHttpClient()
+            : base()
+        {
+
+        }
+
+        public async Task<TokenResponse> GetTokenResponse(CancellationToken cancellationToken)
+        {
+            return await oAuthHttpHandler.GetTokenResponse(cancellationToken);
+        }
+
+        public async Task<TokenResponse> RefreshTokenResponse(CancellationToken cancellationToken)
+        {
+            return await oAuthHttpHandler.RefreshTokenResponse(cancellationToken);
+        }
+
+        public static OAuthHttpClient Factory(OAuthHttpHandlerOptions options)
+        {
+            var oAuthHttpHandler = new OAuthHttpHandler(options);
+            var oAuthHttpClient = new OAuthHttpClient(oAuthHttpHandler);
+            oAuthHttpClient.oAuthHttpHandler = oAuthHttpHandler;
+            return oAuthHttpClient;
+        }
+
+
+    }
+}

--- a/src/OAuth2ClientHandler/OAuthHttpHandler.cs
+++ b/src/OAuth2ClientHandler/OAuthHttpHandler.cs
@@ -14,7 +14,7 @@ namespace OAuth2ClientHandler
         private OAuthHttpHandlerOptions options;
         private bool ownsHandler = false;
         private IAuthorizer authorizer;
-        private TokenResponse tokenResponse;
+        internal TokenResponse tokenResponse;
         private SemaphoreSlim semaphore = new SemaphoreSlim(1, 1);
 
         public OAuthHttpHandler(OAuthHttpHandlerOptions options)
@@ -58,7 +58,7 @@ namespace OAuth2ClientHandler
             return response;
         }
 
-        private async Task<TokenResponse> GetTokenResponse(CancellationToken cancellationToken)
+        internal async Task<TokenResponse> GetTokenResponse(CancellationToken cancellationToken)
         {
             try
             {
@@ -73,14 +73,18 @@ namespace OAuth2ClientHandler
             }
         }
 
-        private async Task<TokenResponse> RefreshTokenResponse(CancellationToken cancellationToken)
+        internal async Task<TokenResponse> RefreshTokenResponse(CancellationToken cancellationToken)
         {
             try
             {
                 semaphore.Wait(cancellationToken);
                 if (cancellationToken.IsCancellationRequested) return null;
-                tokenResponse = await authorizer.GetToken(cancellationToken);
+                tokenResponse = await authorizer.RefreshToken(tokenResponse, cancellationToken);
                 return tokenResponse;
+            }
+            catch (Exception e)
+            {
+                throw e;
             }
             finally
             {

--- a/src/OAuth2ClientHandler/packages.config
+++ b/src/OAuth2ClientHandler/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>

--- a/tests/OAuth2ClientHandler.Tests/OAuth2ClientHandler.Tests.csproj
+++ b/tests/OAuth2ClientHandler.Tests/OAuth2ClientHandler.Tests.csproj
@@ -57,8 +57,8 @@
       <HintPath>..\..\packages\Microsoft.Owin.Testing.3.0.1\lib\net45\Microsoft.Owin.Testing.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">

--- a/tests/OAuth2ClientHandler.Tests/app.config
+++ b/tests/OAuth2ClientHandler.Tests/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/OAuth2ClientHandler.Tests/packages.config
+++ b/tests/OAuth2ClientHandler.Tests/packages.config
@@ -8,7 +8,7 @@
   <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security.OAuth" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Testing" version="3.0.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- Change DataContractJsonSerializer to JsonConvert.DeserializeObject to prevent element root error
- Add refresh token method to client_credentials flow instead create new token
- Create a factory that returns a HttpClient with tokenResponse, refresh and get token methods
