### PR TITLE
Add Form credentials

### DIFF
--- a/src/OAuth2ClientHandler/Authorizer/AuthorizerOptions.cs
+++ b/src/OAuth2ClientHandler/Authorizer/AuthorizerOptions.cs
@@ -14,6 +14,7 @@ namespace OAuth2ClientHandler.Authorizer
         public string Password { get; set; }
         public IEnumerable<string> Scope { get; set; }
         public GrantType GrantType { get; set; }
+        public CredentialsType CredentialsType { get; set; }
         public Action<HttpStatusCode, string> OnError { get; set; }
     }
 }

--- a/src/OAuth2ClientHandler/CredentialsType.cs
+++ b/src/OAuth2ClientHandler/CredentialsType.cs
@@ -1,0 +1,8 @@
+﻿namespace OAuth2ClientHandler
+{
+    public enum CredentialsType
+    {
+        Basic,
+        Form
+    }
+}

--- a/src/OAuth2ClientHandler/OAuth2ClientHandler.csproj
+++ b/src/OAuth2ClientHandler/OAuth2ClientHandler.csproj
@@ -43,6 +43,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CredentialsType.cs" />
     <Compile Include="Authorizer\IAuthorizer.cs" />
     <Compile Include="Authorizer\Authorizer.cs" />
     <Compile Include="Authorizer\AuthorizerOptions.cs" />

--- a/tests/OAuth2ClientHandler.Tests/AuthorizerBasicCredentialsTests.cs
+++ b/tests/OAuth2ClientHandler.Tests/AuthorizerBasicCredentialsTests.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Owin.Testing;
+using NUnit.Framework;
+
+namespace OAuth2ClientHandler.Tests
+{
+    [TestFixture]
+    public class AuthorizerBasicCredentialsTests : AuthorizerTests
+    {
+        public AuthorizerBasicCredentialsTests() : base(CredentialsType.Basic)
+        {
+        }
+    }
+}

--- a/tests/OAuth2ClientHandler.Tests/AuthorizerFormCredentialsTests.cs
+++ b/tests/OAuth2ClientHandler.Tests/AuthorizerFormCredentialsTests.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Owin.Testing;
+using NUnit.Framework;
+
+namespace OAuth2ClientHandler.Tests
+{
+    [TestFixture]
+    public class AuthorizerFormCredentialsTests : AuthorizerTests
+    {
+        public AuthorizerFormCredentialsTests() : base(CredentialsType.Form)
+        {
+        }
+    }
+}

--- a/tests/OAuth2ClientHandler.Tests/AuthorizerTests.cs
+++ b/tests/OAuth2ClientHandler.Tests/AuthorizerTests.cs
@@ -7,19 +7,18 @@ using OAuth2ClientHandler.Authorizer;
 
 namespace OAuth2ClientHandler.Tests
 {
-    [TestFixture]
-    public class AuthorizerTests
+    public abstract class AuthorizerTests : IDisposable
     {
-        private TestServer server;
+        private readonly CredentialsType credentialsType;
+        private readonly TestServer server;
 
-        [TestFixtureSetUp]
-        public void FixtureSetUp()
+        protected AuthorizerTests(CredentialsType credentialsType)
         {
-            server = TestServer.Create<Startup>();
+            this.credentialsType = credentialsType;
+            this.server = TestServer.Create(new Startup(credentialsType).Configuration);
         }
 
-        [TestFixtureTearDown]
-        public void FixtureTearDown()
+        public void Dispose()
         {
             server.Dispose();
         }
@@ -33,7 +32,8 @@ namespace OAuth2ClientHandler.Tests
                 TokenEndpointUrl = new Uri("http://localhost/token"),
                 ClientId = "MyId",
                 ClientSecret = "MySecret",
-                GrantType = GrantType.ClientCredentials
+                GrantType = GrantType.ClientCredentials,
+                CredentialsType = credentialsType
             };
 
             var authorizer = new Authorizer.Authorizer(options, () => server.HttpClient);
@@ -50,7 +50,8 @@ namespace OAuth2ClientHandler.Tests
                 TokenEndpointUrl = new Uri("http://localhost/token"),
                 ClientId = "WrongId",
                 ClientSecret = "WrongSecret",
-                GrantType = GrantType.ClientCredentials
+                GrantType = GrantType.ClientCredentials,
+                CredentialsType = credentialsType
             };
 
             var authorizer = new Authorizer.Authorizer(options, () => server.HttpClient);
@@ -74,6 +75,7 @@ namespace OAuth2ClientHandler.Tests
                 ClientId = "WrongId",
                 ClientSecret = "WrongSecret",
                 GrantType = GrantType.ClientCredentials,
+                CredentialsType = credentialsType,
                 OnError = (statusCode, message) =>
                 {
                     errorStatusCode = statusCode;
@@ -98,7 +100,8 @@ namespace OAuth2ClientHandler.Tests
                 TokenEndpointUrl = new Uri("http://localhost/invalid"),
                 ClientId = "MyId",
                 ClientSecret = "MySecret",
-                GrantType = GrantType.ClientCredentials
+                GrantType = GrantType.ClientCredentials,
+                CredentialsType = credentialsType
             };
 
             var authorizer = new Authorizer.Authorizer(options, () => server.HttpClient);
@@ -116,6 +119,7 @@ namespace OAuth2ClientHandler.Tests
                 ClientId = "MyId",
                 ClientSecret = "MySecret",
                 GrantType = GrantType.ClientCredentials,
+                CredentialsType = credentialsType,
                 Scope = new[] { "testscope" }
             };
 
@@ -135,7 +139,8 @@ namespace OAuth2ClientHandler.Tests
                 ClientSecret = "MySecret",
                 Username = "MyUsername",
                 Password = "MyPassword",
-                GrantType = GrantType.ResourceOwnerPasswordCredentials
+                GrantType = GrantType.ResourceOwnerPasswordCredentials,
+                CredentialsType = credentialsType
             };
 
             var authorizer = new Authorizer.Authorizer(options, () => server.HttpClient);
@@ -154,7 +159,8 @@ namespace OAuth2ClientHandler.Tests
                 ClientSecret = "MySecret",
                 Username = "MyUsername",
                 Password = "WrongPassword",
-                GrantType = GrantType.ResourceOwnerPasswordCredentials
+                GrantType = GrantType.ResourceOwnerPasswordCredentials,
+                CredentialsType = credentialsType
             };
 
             var authorizer = new Authorizer.Authorizer(options, () => server.HttpClient);
@@ -180,6 +186,7 @@ namespace OAuth2ClientHandler.Tests
                 Username = "MyUsername",
                 Password = "WrongPassword",
                 GrantType = GrantType.ResourceOwnerPasswordCredentials,
+                CredentialsType = credentialsType,
                 OnError = (statusCode, message) =>
                 {
                     errorStatusCode = statusCode;
@@ -207,6 +214,7 @@ namespace OAuth2ClientHandler.Tests
                 Username = "MyUsername",
                 Password = "MyPassword",
                 GrantType = GrantType.ResourceOwnerPasswordCredentials,
+                CredentialsType = credentialsType,
                 Scope = new[] { "othertestscope" }
             };
 

--- a/tests/OAuth2ClientHandler.Tests/OAuth2ClientHandler.Tests.csproj
+++ b/tests/OAuth2ClientHandler.Tests/OAuth2ClientHandler.Tests.csproj
@@ -93,6 +93,8 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="AuthorizerBasicCredentialsTests.cs" />
+    <Compile Include="AuthorizerFormCredentialsTests.cs" />
     <Compile Include="AuthorizerTests.cs" />
     <Compile Include="Helpers\TestController.cs" />
     <Compile Include="OAuthMessageHandlerTests.cs" />


### PR DESCRIPTION
Some servers do not support basic authentication credentials.
Therefore, create an option to specify whether basic authentication or
form credentials should be sent.