### PR TITLE
Remove explicit setting of inner handler in OAuthHttpHandler

### DIFF
--- a/src/OAuth2ClientHandler/OAuthHttpHandler.cs
+++ b/src/OAuth2ClientHandler/OAuthHttpHandler.cs
@@ -19,9 +19,11 @@ namespace OAuth2ClientHandler
         {
             if (options == null) { throw new ArgumentNullException(nameof(options)); }
 
-#if NETFRAMEWORK
-            InnerHandler = options.InnerHandler ?? _defaultHttpHandler.Value;
-#endif
+            if (options.InnerHandler != null)
+            {
+                InnerHandler = options.InnerHandler;
+            }
+
             _authorizer = new Authorizer.Authorizer(options.AuthorizerOptions, createAuthorizerHttpClient ?? (() => new HttpClient(options.InnerHandler ?? _defaultHttpHandler.Value, false)));
         }
 

--- a/src/OAuth2ClientHandler/OAuthHttpHandler.cs
+++ b/src/OAuth2ClientHandler/OAuthHttpHandler.cs
@@ -19,6 +19,9 @@ namespace OAuth2ClientHandler
         {
             if (options == null) { throw new ArgumentNullException(nameof(options)); }
 
+#if NETFRAMEWORK
+            InnerHandler = options.InnerHandler ?? _defaultHttpHandler.Value;
+#endif
             _authorizer = new Authorizer.Authorizer(options.AuthorizerOptions, createAuthorizerHttpClient ?? (() => new HttpClient(options.InnerHandler ?? _defaultHttpHandler.Value, false)));
         }
 

--- a/src/OAuth2ClientHandler/OAuthHttpHandler.cs
+++ b/src/OAuth2ClientHandler/OAuthHttpHandler.cs
@@ -11,25 +11,26 @@ namespace OAuth2ClientHandler
     public class OAuthHttpHandler : DelegatingHandler
     {
         private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
-        private readonly OAuthHttpHandlerOptions _options;
-        private readonly bool _ownsHandler = false;
         private readonly IAuthorizer _authorizer;
         private TokenResponse _tokenResponse;
+        private readonly Lazy<HttpClientHandler> _defaultHttpHandler = new Lazy<HttpClientHandler>(() => new HttpClientHandler());
 
-        public OAuthHttpHandler(OAuthHttpHandlerOptions options)
+        public OAuthHttpHandler(OAuthHttpHandlerOptions options, Func<HttpClient> createAuthorizerHttpClient = null) 
         {
-            _options = options ?? throw new ArgumentNullException(nameof(options));
-            InnerHandler = options.InnerHandler ?? new HttpClientHandler();
-            _ownsHandler = options.InnerHandler == null;
-            _authorizer = new Authorizer.Authorizer(options.AuthorizerOptions, () => new HttpClient(InnerHandler, false));
+            if (options == null) { throw new ArgumentNullException(nameof(options)); }
+
+            _authorizer = new Authorizer.Authorizer(options.AuthorizerOptions, createAuthorizerHttpClient ?? (() => new HttpClient(options.InnerHandler ?? _defaultHttpHandler.Value, false)));
         }
 
+        
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
 
-            if (disposing && _ownsHandler)
-                InnerHandler.Dispose();
+            if (disposing && _defaultHttpHandler.IsValueCreated)
+            {
+                _defaultHttpHandler.Value.Dispose();
+            }
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/tests/OAuth2ClientHandler.Tests.NetCore/OAuth2ClientHandler.Tests.NetCore.csproj
+++ b/tests/OAuth2ClientHandler.Tests.NetCore/OAuth2ClientHandler.Tests.NetCore.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="IdentityServer4" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.10.0" />


### PR DESCRIPTION
This is to address exception risen in newer versions of the HttpClientFactory:
System.InvalidOperationException: The 'InnerHandler' property must be null. 'DelegatingHandler' instances provided to 'HttpMessageHandlerBuilder' must not be reused or cached.