### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/tests/OAuth2ClientHandler.Tests.NetCore/OAuth2ClientHandler.Tests.NetCore.csproj
+++ b/tests/OAuth2ClientHandler.Tests.NetCore/OAuth2ClientHandler.Tests.NetCore.csproj
@@ -7,16 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityServer4" Version="2.4.0" />
+    <PackageReference Include="IdentityServer4" Version="2.5.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.10.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi@huysentruitw, I found an issue in the OAuth2ClientHandler.Tests.NetCore.csproj:

Packages IdentityServer4 v2.4.0, Newtonsoft.Json v12.0.2, NUnit v3.11.0, NUnit.ConsoleRunner v3.10.0, Microsoft.NET.Test.Sdk v16.0.1 and NUnit3TestAdapter v3.13.0 transitively introduce 141 dependencies into oauth2-client-handler’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/oauth2-client-handler.html)), while IdentityServer4 v2.5.4, Newtonsoft.Json v12.0.3, NUnit v3.13.2, NUnit.ConsoleRunner v3.11.1, Microsoft.NET.Test.Sdk v16.1.0 and NUnit3TestAdapter v4.0.0 can only introduce 98 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/oauth2-client-handler_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose