### PR TITLE
avoid deadlocks (synchronous code+ASP.NET Framework)

### DIFF
--- a/src/OAuth2ClientHandler/Authorizer/Authorizer.cs
+++ b/src/OAuth2ClientHandler/Authorizer/Authorizer.cs
@@ -32,9 +32,9 @@ namespace OAuth2ClientHandler.Authorizer
             switch (_options.GrantType)
             {
                 case GrantType.ClientCredentials:
-                    return await GetTokenWithClientCredentials(cancellationToken.Value);
+                    return await GetTokenWithClientCredentials(cancellationToken.Value).ConfigureAwait(false);
                 case GrantType.ResourceOwnerPasswordCredentials:
-                    return await GetTokenWithResourceOwnerPasswordCredentials(cancellationToken.Value);
+                    return await GetTokenWithResourceOwnerPasswordCredentials(cancellationToken.Value).ConfigureAwait(false);
                 default:
                     throw new NotSupportedException($"Requested grant type '{_options.GrantType}' is not supported");
             }
@@ -93,17 +93,17 @@ namespace OAuth2ClientHandler.Authorizer
 
                 var content = new FormUrlEncodedContent(properties);
 
-                var response = await client.PostAsync(_options.TokenEndpointUrl, content, cancellationToken);
+                var response = await client.PostAsync(_options.TokenEndpointUrl, content, cancellationToken).ConfigureAwait(false);
                 if (cancellationToken.IsCancellationRequested) return null;
 
                 if (!response.IsSuccessStatusCode)
                 {
-                    RaiseProtocolException(response.StatusCode, await response.Content.ReadAsStringAsync());
+                    RaiseProtocolException(response.StatusCode, await response.Content.ReadAsStringAsync().ConfigureAwait(false));
                     return null;
                 }
 
                 var serializer = new DataContractJsonSerializer(typeof(TokenResponse));
-                return serializer.ReadObject(await response.Content.ReadAsStreamAsync()) as TokenResponse;
+                return serializer.ReadObject(await response.Content.ReadAsStreamAsync().ConfigureAwait(false)) as TokenResponse;
             }
         }
 

--- a/src/OAuth2ClientHandler/OAuthHttpHandler.cs
+++ b/src/OAuth2ClientHandler/OAuthHttpHandler.cs
@@ -40,20 +40,20 @@ namespace OAuth2ClientHandler
         {
             if (request.Headers.Authorization == null)
             {
-                var tokenResponse = await GetTokenResponse(cancellationToken);
+                var tokenResponse = await GetTokenResponse(cancellationToken).ConfigureAwait(false);
                 if (tokenResponse != null)
                     request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokenResponse.AccessToken);
             }
 
-            var response = await base.SendAsync(request, cancellationToken);
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
             {
-                var tokenResponse = await RefreshTokenResponse(cancellationToken);
+                var tokenResponse = await RefreshTokenResponse(cancellationToken).ConfigureAwait(false);
                 if (tokenResponse != null)
                 {
                     request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokenResponse.AccessToken);
-                    response = await base.SendAsync(request, cancellationToken);
+                    response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 }
             }
 
@@ -64,9 +64,9 @@ namespace OAuth2ClientHandler
         {
             try
             {
-                _semaphore.Wait(cancellationToken);
+                await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 if (cancellationToken.IsCancellationRequested) return null;
-                _tokenResponse = _tokenResponse ?? await _authorizer.GetToken(cancellationToken);
+                _tokenResponse = _tokenResponse ?? await _authorizer.GetToken(cancellationToken).ConfigureAwait(false);
                 return _tokenResponse;
             }
             finally
@@ -79,9 +79,9 @@ namespace OAuth2ClientHandler
         {
             try
             {
-                _semaphore.Wait(cancellationToken);
+                await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 if (cancellationToken.IsCancellationRequested) return null;
-                _tokenResponse = await _authorizer.GetToken(cancellationToken);
+                _tokenResponse = await _authorizer.GetToken(cancellationToken).ConfigureAwait(false);
                 return _tokenResponse;
             }
             finally


### PR DESCRIPTION
avoid deadlocks when calling OAuthHttpHandler in synchronous code using `.GetAwaiter().GetResult()` and a SynchronizationContext is present (e.g. ASP.NET Framework):
* use `.ConfigureAwait(false)`
* use async variant of `SemaphoreSlim.Wait()`

I can reproduce the deadlock when I place the following test in `OAuth2ClientHandler.Tests.Net45.OAuthMessageHandlerTests` and use [Nito.AsyncEx.AsyncContext.Run](https://www.nuget.org/packages/Nito.AsyncEx/5.1.2/) to simulate a SynchronizationContext (see [here](https://stackoverflow.com/a/14103674)):
```
[Test]
public void OAuthHttpHandler_GetAwaiterGetResult_ShouldNotCauseDeadlock()
{
    var options = new OAuthHttpHandlerOptions
    {
        AuthorizerOptions = new AuthorizerOptions
        {
            AuthorizeEndpointUrl = new Uri("http://localhost/authorizer"),
            TokenEndpointUrl = new Uri("http://localhost/token"),
            ClientId = "MyId",
            ClientSecret = "MySecret",
            GrantType = GrantType.ClientCredentials
        },
        InnerHandler = Handler
    };

    Nito.AsyncEx.AsyncContext.Run(() =>
    {
        Assert.IsNotNull( SynchronizationContext.Current );
        using (var client = new HttpClient(new OAuthHttpHandler(options)) { Timeout = TimeSpan.FromSeconds(600)})
        {
            client.BaseAddress = new Uri("http://localhost");
            var response = client.GetAsync("/api/authorize").GetAwaiter().GetResult();
            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
        }
    });
}
```     

Unfortunately, I was not able to get the test running. Maybe there is another reason for that.
        